### PR TITLE
Use 'yyyy' (year-of-era) instead of YYYY (week-based-year)

### DIFF
--- a/src/main/java/io/javaalmanac/snippets/time/WorldClock.java
+++ b/src/main/java/io/javaalmanac/snippets/time/WorldClock.java
@@ -10,18 +10,18 @@ import java.util.Locale;
  * Print the current time in all time zones known to the JDK (from the [tz
  * database](https://en.wikipedia.org/wiki/Tz_database)) together with their
  * current UTC offset and the DST status.
- * 
+ *
  * @title World Clock
  * @category api.time
  * @since 8
  */
 public class WorldClock {
 
-	static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("E, YYYY-MM-dd HH:mm:ss  xxx", Locale.US);
+	static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("E, yyyy-MM-dd HH:mm:ss  xxx", Locale.US);
 
-	private static void print(ZonedDateTime t) {
+	static String format(ZonedDateTime t) {
 		String dst = t.getZone().getRules().isDaylightSavings(t.toInstant()) ? "DST" : "";
-		System.out.printf("%-32s %s  %s\n", t.getZone(), t.format(FORMATTER), dst);
+		return "%-32s %s  %s".formatted(t.getZone(), t.format(FORMATTER), dst);
 	}
 
 	public static void main(String... args) {
@@ -31,7 +31,8 @@ public class WorldClock {
 				.map(ZoneId::of) //
 				.map((ZoneId z) -> ZonedDateTime.ofInstant(now, z)) //
 				.sorted() //
-				.forEach(WorldClock::print);
+				.map(WorldClock::format)
+				.forEach(System.out::println);
 	}
 
 }

--- a/src/test/java/io/javaalmanac/snippets/time/WorldClockTest.java
+++ b/src/test/java/io/javaalmanac/snippets/time/WorldClockTest.java
@@ -1,10 +1,14 @@
 package io.javaalmanac.snippets.time;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 import io.javaalmanac.snippets.ConsoleGrabber;
+
+import java.time.ZonedDateTime;
 
 public class WorldClockTest {
 
@@ -15,6 +19,13 @@ public class WorldClockTest {
 		var lines = grabber.lines();
 		assertTrue(lines.size() > 500);
 		lines.stream().reduce(this::assertOrder);
+	}
+
+	@Test
+	void test_format() {
+		ZonedDateTime dateTime = ZonedDateTime.parse("2007-12-31T12:01:02+01:00[Europe/Warsaw]");
+		String actual = WorldClock.format(dateTime);
+		assertEquals("Europe/Warsaw                    Mon, 2007-12-31 12:01:02  +01:00  ", actual);
 	}
 
 	String assertOrder(String l1, String l2) {


### PR DESCRIPTION
`DateTimeFormatter` in `io.javaalmanac.snippets.time.WorldClock` used 'YYYY' which is week-based-year what leads to incorrect data when given week is spanned between two consecutive years.